### PR TITLE
fix(user_schema): forces recreation of the user record if the tenant id changes.

### DIFF
--- a/fusionauth/resource_fusionauth_user_schema.go
+++ b/fusionauth/resource_fusionauth_user_schema.go
@@ -14,6 +14,7 @@ func userSchemaV1() *schema.Resource {
 			"tenant_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				Description:  "The unique Id of the tenant used to scope this API request.",
 				ValidateFunc: validation.IsUUID,
 			},


### PR DESCRIPTION
I created a new tenant and Terraform got in a funk when I tried to migrate users to the new tenant as it couldn't update existing user's tenant ids (it's a read-only field and forced recreation is the only way to move users).