### PR TITLE
bugfix(idp_facebook): fixes individual app registration configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This provider is used for setting up [FusionAuth](https://fusionauth.io)
     - Google
     - Apple
     - External JWT
+    - Facebook
     - SAML v2
     - Sony PSN
     - Steam

--- a/fusionauth/resource_fusionauth_idp_facebook.go
+++ b/fusionauth/resource_fusionauth_idp_facebook.go
@@ -18,7 +18,7 @@ type FacebookAppConfig struct {
 	AppID              string `json:"appId,omitempty"`
 	ButtonText         string `json:"buttonText,omitempty"`
 	ClientSecret       string `json:"client_secret,omitempty"`
-	CreateRegistration bool   `json:"createRegistration,omitempty"`
+	CreateRegistration bool   `json:"createRegistration"`
 	Enabled            bool   `json:"enabled"`
 	Fields             string `json:"fields,omitempty"`
 	Permissions        string `json:"permissions,omitempty"`


### PR DESCRIPTION
Thanks to Go's omitempty functionality when serialising JSON, FusionAuth doesn't know what to do if it doesn't receive a boolean value for a property and injects the default value, even if `false` was configured.