### PR TITLE
bugfix(idp): fixes individual app idp enabled configuration.

### DIFF
--- a/fusionauth/resource_fusionauth_idp_apple.go
+++ b/fusionauth/resource_fusionauth_idp_apple.go
@@ -17,7 +17,7 @@ type AppleIdentityProviderBody struct {
 type AppleAppConfig struct {
 	ButtonText         string `json:"buttonText,omitempty"`
 	CreateRegistration bool   `json:"createRegistration"`
-	Enabled            bool   `json:"enabled,omitempty"`
+	Enabled            bool   `json:"enabled"`
 	KeyID              string `json:"keyId,omitempty"`
 	Scope              string `json:"scope,omitempty"`
 	ServicesID         string `json:"servicesId,omitempty"`

--- a/fusionauth/resource_fusionauth_idp_external_jwt.go
+++ b/fusionauth/resource_fusionauth_idp_external_jwt.go
@@ -17,7 +17,7 @@ type IDPExternalJWTProviderBody struct {
 
 type IDPExternalJWTAppConfig struct {
 	CreateRegistration bool `json:"createRegistration"`
-	Enabled            bool `json:"enabled,omitempty"`
+	Enabled            bool `json:"enabled"`
 }
 
 func resourceIDPExternalJWT() *schema.Resource {

--- a/fusionauth/resource_fusionauth_idp_facebook.go
+++ b/fusionauth/resource_fusionauth_idp_facebook.go
@@ -19,7 +19,7 @@ type FacebookAppConfig struct {
 	ButtonText         string `json:"buttonText,omitempty"`
 	ClientSecret       string `json:"client_secret,omitempty"`
 	CreateRegistration bool   `json:"createRegistration,omitempty"`
-	Enabled            bool   `json:"enabled,omitempty"`
+	Enabled            bool   `json:"enabled"`
 	Fields             string `json:"fields,omitempty"`
 	Permissions        string `json:"permissions,omitempty"`
 }

--- a/fusionauth/resource_fusionauth_idp_google.go
+++ b/fusionauth/resource_fusionauth_idp_google.go
@@ -20,7 +20,7 @@ type GoogleAppConfig struct {
 	ClientSecret       string `json:"client_secret,omitempty"`
 	Scope              string `json:"scope,omitempty"`
 	CreateRegistration bool   `json:"createRegistration"`
-	Enabled            bool   `json:"enabled,omitempty"`
+	Enabled            bool   `json:"enabled"`
 }
 
 func newIDPGoogle() *schema.Resource {

--- a/fusionauth/resource_fusionauth_idp_open_id_connect.go
+++ b/fusionauth/resource_fusionauth_idp_open_id_connect.go
@@ -19,7 +19,7 @@ type OpenIDAppConfig struct {
 	ButtonText         string          `json:"buttonText,omitempty"`
 	OAuth2             OAuth2AppConfig `json:"oauth2,omitempty"`
 	CreateRegistration bool            `json:"createRegistration"`
-	Enabled            bool            `json:"enabled,omitempty"`
+	Enabled            bool            `json:"enabled"`
 }
 
 type OAuth2AppConfig struct {

--- a/fusionauth/resource_fusionauth_idp_samlv2.go
+++ b/fusionauth/resource_fusionauth_idp_samlv2.go
@@ -18,7 +18,7 @@ type SAMLAppConfig struct {
 	ButtonImageURL     string `json:"buttonImageURL,omitempty"`
 	ButtonText         string `json:"buttonText,omitempty"`
 	CreateRegistration bool   `json:"createRegistration"`
-	Enabled            bool   `json:"enabled,omitempty"`
+	Enabled            bool   `json:"enabled"`
 }
 
 func resourceIDPSAMLv2() *schema.Resource {

--- a/fusionauth/resource_fusionauth_idp_samlv2_idp_initiated.go
+++ b/fusionauth/resource_fusionauth_idp_samlv2_idp_initiated.go
@@ -16,7 +16,7 @@ type SAMLIDPInitiatedIdentityProviderBody struct {
 
 type SAMLIDPInitiatedAppConfig struct {
 	CreateRegistration bool `json:"createRegistration"`
-	Enabled            bool `json:"enabled,omitempty"`
+	Enabled            bool `json:"enabled"`
 }
 
 func resourceIDPSAMLv2IdPInitiated() *schema.Resource {

--- a/fusionauth/resource_fusionauth_idp_sony_psn.go
+++ b/fusionauth/resource_fusionauth_idp_sony_psn.go
@@ -19,7 +19,7 @@ type SonyPSNAppConfig struct {
 	ClientID           string `json:"client_id,omitempty"`
 	ClientSecret       string `json:"client_secret,omitempty"`
 	CreateRegistration bool   `json:"createRegistration"`
-	Enabled            bool   `json:"enabled,omitempty"`
+	Enabled            bool   `json:"enabled"`
 	Scope              string `json:"scope,omitempty"`
 }
 

--- a/fusionauth/resource_fusionauth_idp_steam.go
+++ b/fusionauth/resource_fusionauth_idp_steam.go
@@ -19,7 +19,7 @@ type SteamAppConfig struct {
 	ClientID   string `json:"client_id,omitempty"`
 	// ClientSecret       string `json:"client_secret,omitempty"`
 	CreateRegistration bool   `json:"createRegistration"`
-	Enabled            bool   `json:"enabled,omitempty"`
+	Enabled            bool   `json:"enabled"`
 	Scope              string `json:"scope,omitempty"`
 	WebAPIKey          string `json:"webAPIKey,omitempty"`
 }

--- a/fusionauth/resource_fusionauth_idp_twitch.go
+++ b/fusionauth/resource_fusionauth_idp_twitch.go
@@ -19,7 +19,7 @@ type TwitchAppConfig struct {
 	ClientID           string `json:"client_id,omitempty"`
 	ClientSecret       string `json:"client_secret,omitempty"`
 	CreateRegistration bool   `json:"createRegistration"`
-	Enabled            bool   `json:"enabled,omitempty"`
+	Enabled            bool   `json:"enabled"`
 	Scope              string `json:"scope,omitempty"`
 }
 

--- a/fusionauth/resource_fusionauth_idp_xbox.go
+++ b/fusionauth/resource_fusionauth_idp_xbox.go
@@ -19,7 +19,7 @@ type XboxAppConfig struct {
 	ClientID           string `json:"client_id,omitempty"`
 	ClientSecret       string `json:"client_secret,omitempty"`
 	CreateRegistration bool   `json:"createRegistration"`
-	Enabled            bool   `json:"enabled,omitempty"`
+	Enabled            bool   `json:"enabled"`
 	Scope              string `json:"scope,omitempty"`
 }
 


### PR DESCRIPTION
Similar to #79, `omitempty` is configured on the IDP individual app configuration Enabled property.
Leads to FusionAuth not disabling an enabled application, if the property is toggled to `false` in the Terraform configuration.