### PR TITLE
fix: users losing group assignment on update

### DIFF
--- a/fusionauth/resource_fusionauth_group.go
+++ b/fusionauth/resource_fusionauth_group.go
@@ -32,7 +32,6 @@ func newGroup() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Description: "The Application Roles to assign to this group.",
-				ForceNew:    true,
 			},
 			"tenant_id": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
Re-creating FA group on every role changes causes users to lose the group assignment (as the group UUID changes). By not forcing the recreation of TF resource, one can dynamically modify roles without risk of losing existing assignments.

Not re-creating the group is also more in alignment with the [existing group resource documentation](https://registry.terraform.io/providers/gpsinsight/fusionauth/latest/docs/resources/group#role_ids).

I am not sure how TF [handles migrations](https://www.terraform.io/plugin/sdkv2/resources/state-migration). Maybe it would be better to keep this behavior and migrate the old users to the new group, although this would put strain on FusionAuth's API?

Below is example of removing `role_id` causing replacement of the whole group.
```hcl
  # fusionauth_group.viewer_internal must be replaced
-/+ resource "fusionauth_group" "viewer_internal" {
      - data      = {} -> null
      ~ id        = "85646281-64f5-4cd6-9f9b-5442e8fd3cab" -> (known after apply)
        name      = "Application-ViewerInternal"
      ~ role_ids  = [ # forces replacement
          - "9c744315-5ff1-4a30-9205-bce8b30312fb",
            # (6 unchanged elements hidden)
        ]
        # (1 unchanged attribute hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
``` 