### PR TITLE
Add refresh_token_expiration_policy to jwt_configuration

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -109,6 +109,7 @@ resource "fusionauth_application" "Forum" {
     - `enabled` - (Optional) Indicates if this application is using the JWT configuration defined here or the global JWT configuration defined by the System Configuration. If this is false the signing algorithm configured in the System Configuration will be used. If true the signing algorithm defined in this application will be used.
     - `id_token_key_id` - (Optional) The Id of the signing key used to sign the Id token.
     - `refresh_token_ttl_minutes` - (Optional) The length of time in minutes the JWT refresh token will live before it is expired and is not able to be exchanged for a JWT.
+    - `refresh_token_expiration_policy` - (Optional) The Refresh Token expiration policy. The possible values are: Fixed - the expiration is calculated from the time the token is issued.  SlidingWindow - the expiration is calculated from the last time the token was used.
     - `ttl_seconds` - (Optional) The length of time in seconds the JWT will live before it is expired and no longer valid.
 * `lambda_configuration` - (Optional)
     - `access_token_populate_id` - (Optional) The Id of the Lambda that will be invoked when an access token is generated for this application. This will be utilized during OAuth2 and OpenID Connect authentication requests as well as when an access token is generated for the Login API.

--- a/fusionauth/resource_fusionauth_application.go
+++ b/fusionauth/resource_fusionauth_application.go
@@ -710,6 +710,16 @@ func newJWTConfiguration() *schema.Resource {
 				Default:     43200,
 				Description: "The length of time in minutes the JWT refresh token will live before it is expired and is not able to be exchanged for a JWT.",
 			},
+			"refresh_token_expiration_policy": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     fusionauth.RefreshTokenExpirationPolicy_Fixed.String(),
+				Description: "The Refresh Token expiration policy. The possible values are: Fixed - the expiration is calculated from the time the token is issued.  SlidingWindow - the expiration is calculated from the last time the token was used.",
+				ValidateFunc: validation.StringInSlice([]string{
+					fusionauth.RefreshTokenExpirationPolicy_SlidingWindow.String(),
+					fusionauth.RefreshTokenExpirationPolicy_Fixed.String(),
+				}, false),
+			},
 			"ttl_seconds": {
 				Type:        schema.TypeInt,
 				Optional:    true,

--- a/fusionauth/resource_fusionauth_application.go
+++ b/fusionauth/resource_fusionauth_application.go
@@ -718,7 +718,23 @@ func newJWTConfiguration() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					fusionauth.RefreshTokenExpirationPolicy_SlidingWindow.String(),
 					fusionauth.RefreshTokenExpirationPolicy_Fixed.String(),
+					"SlidingWindowWithMaximumLifetime",
 				}, false),
+			},
+			"refresh_token_sliding_window_configuration": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"maximum_time_to_live_in_minutes": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Default:     43200,
+							Description: "The maximum lifetime of a refresh token when using a refreshTokenExpirationPolicy of SlidingWindowWithMaximumLifetime. Value must be greater than 0.",
+						},
+					},
+				},
 			},
 			"ttl_seconds": {
 				Type:        schema.TypeInt,

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -282,8 +282,24 @@ func newTenant() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								"Fixed",
 								"SlidingWindow",
+								"SlidingWindowWithMaximumLifetime",
 							}, false),
 							Description: "The refresh token expiration policy.",
+						},
+						"refresh_token_sliding_window_configuration": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"maximum_time_to_live_in_minutes": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Default:     43200,
+										Description: "The maximum lifetime of a refresh token when using a refreshTokenExpirationPolicy of SlidingWindowWithMaximumLifetime. Value must be greater than 0.",
+									},
+								},
+							},
 						},
 						"refresh_token_revocation_policy_on_login_prevented": {
 							Type:        schema.TypeBool,

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -196,6 +196,8 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttrSet(tfResourcePath, "jwt_configuration.0.id_token_key_id"),
 		resource.TestCheckResourceAttr(tfResourcePath, "jwt_configuration.0.refresh_token_time_to_live_in_minutes", "43200"),
 		resource.TestCheckResourceAttr(tfResourcePath, "jwt_configuration.0.time_to_live_in_seconds", "3600"),
+		resource.TestCheckResourceAttr(tfResourcePath, "jwt_configuration.0.refresh_token_expiration_policy", "SlidingWindowWithMaximumLifetime"),
+		resource.TestCheckResourceAttr(tfResourcePath, "jwt_configuration.0.refresh_token_sliding_window_configuration.0.maximum_time_to_live_in_minutes", "400"),
 
 		// login_configuration
 		resource.TestCheckResourceAttr(tfResourcePath, "login_configuration.0.require_authentication", "true"),
@@ -569,7 +571,11 @@ resource "fusionauth_tenant" "test_%[1]s" {
   http_session_max_inactive_interval = 3400
   issuer   = "https://example.com"
   jwt_configuration {
+		refresh_token_expiration_policy = "SlidingWindowWithMaximumLifetime
     refresh_token_time_to_live_in_minutes = 43200
+		refresh_token_sliding_window_configuration {
+			maximum_time_to_live_in_minutes = "test"
+		}
     time_to_live_in_seconds               = 3600
   }
   login_configuration {


### PR DESCRIPTION
Adds support for `refreshTokenExpirationPolicy` as per [API Docs](https://fusionauth.io/docs/v1/tech/apis/applications#request)

```
applications[x].jwtConfiguration.refreshTokenExpirationPolicy [String] AVAILABLE SINCE 1.17.0
The Refresh Token expiration policy.

The possible values are:

Fixed - the expiration is calculated from the time the token is issued.

SlidingWindow - the expiration is calculated from the last time the token was used.

SlidingWindowWithMaximumLifetime - the expiration is calculated from the last time the token was used, or until the maximumTimeToLiveInMinutes is reached.   AVAILABLE SINCE 1.46.0
```