### PR TITLE
Remove invalid parameter for updates

### DIFF
--- a/fusionauth/resource_fusionauth_themes.go
+++ b/fusionauth/resource_fusionauth_themes.go
@@ -497,10 +497,6 @@ func updateTheme(_ context.Context, data *schema.ResourceData, i interface{}) di
 		Theme: buildTheme(data),
 	}
 
-	if srcTheme, ok := data.GetOk("source_theme_id"); ok {
-		req.SourceThemeId = srcTheme.(string)
-	}
-
 	resp, faErrs, err := client.FAClient.UpdateTheme(data.Id(), req)
 	if err != nil {
 		return diag.Errorf("UpdateTheme err: %v", err)


### PR DESCRIPTION
Fusionauth in recent versions stopped ignoring `sourceThemeId` parameter for theme updates and throws an error if it is included in the payload. This parameter is [only available for theme creation](https://fusionauth.io/docs/apis/themes#request-parameters-1) and shouldn't be sent for updates.

I couldn't find any tests around `sourceThemeId` so I think removing it from the update payload is all that is needed to fix this.

Resolves https://github.com/FusionAuth/terraform-provider-fusionauth/issues/224