### PR TITLE
FusionAuth 1.49.0 Add 'Confirmation Required' template to resource_fusionauth_themes to fix theme

### DIFF
--- a/docs/resources/theme.md
+++ b/docs/resources/theme.md
@@ -19,6 +19,7 @@ resource "fusionauth_theme" "mytheme" {
   account_webauthn_add                           = "[#ftl/]"
   account_webauthn_delete                        = "[#ftl/]"
   account_webauthn_index                         = "[#ftl/]"
+  confirmation_required                          = "[#ftl/]"
   email_complete                                 = "[#ftl/]"
   email_sent                                     = "[#ftl/]"
   email_verification_required                    = "[#ftl/]"
@@ -80,6 +81,7 @@ resource "fusionauth_theme" "mytheme" {
 * `account_webauthn_add` - (Optional) A FreeMarker template that is rendered when the user requests the /account/webauthn/add path. This page contains a form that allows a user to register a new WebAuthn passkey.
 * `account_webauthn_delete` - (Optional) A FreeMarker template that is rendered when the user requests the /account/webauthn/delete path. This page contains a form that allows a user to delete a WebAuthn passkey.
 * `account_webauthn_index` - (Optional) A FreeMarker template that is rendered when the user requests the /account/webauthn/ path. This page displays an authenticated user’s registered WebAuthn passkeys. Additionally, it provides links to delete an existing passkey and register a new passkey.
+* `confirmation_required` - (Optional) A FreeMarker template that is rendered when the user requests the /confirmation-required path. This page is displayed when a user attempts to complete an email based workflow that did not begin in the same browser. For example, if the user starts a forgot password workflow, and then opens the link in a separate browser the user will be shown this panel.
 * `email_complete` - (Optional) A FreeMarker template that is rendered when the user requests the /email/complete path. This page is used after a user has verified their email address by clicking the URL in the email. After FusionAuth has updated their user object to indicate that their email was verified, the browser is redirected to this page.
 * `email_sent` - (Optional) A FreeMarker template that is rendered when the user requests the /email/sent path. This page is used after a user has asked for the verification email to be resent. This can happen if the URL in the email expired and the user clicked it. In this case, the user can provide their email address again and FusionAuth will resend the email. After the user submits their email and FusionAuth re-sends a verification email to them, the browser is redirected to this page.
 * `email_verification_required` - (Optional) A FreeMarker template that is rendered when the user requests the /email/verification-required path. This page is rendered when a user is required to verify their email address prior to being allowed to proceed with login. This occurs when Unverified behavior is set to Gated in email verification settings on the Tenant.

--- a/fusionauth/resource_fusionauth_themes.go
+++ b/fusionauth/resource_fusionauth_themes.go
@@ -83,6 +83,13 @@ func newTheme() *schema.Resource {
 				Description:      "A FreeMarker template that is rendered when the user requests the /account/two-factor path. This page displays an authenticated user’s configured multi-factor authentication methods. Additionally, it provides links to enable and disable a method.",
 				DiffSuppressFunc: diffSuppressTemplate,
 			},
+			"confirmation_required": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				Description:      "A FreeMarker template that is rendered when the user requests the /confirmation-required path. This page is displayed when a user attempts to complete an email based workflow that did not begin in the same browser. For example, if the user starts a forgot password workflow, and then opens the link in a separate browser the user will be shown this panel.",
+				DiffSuppressFunc: diffSuppressTemplate,
+			},
 			"account_webauthn_add": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -393,6 +400,7 @@ func buildTheme(data *schema.ResourceData) fusionauth.Theme {
 			AccountTwoFactorDisable:           data.Get("account_two_factor_disable").(string),
 			AccountTwoFactorEnable:            data.Get("account_two_factor_enable").(string),
 			AccountTwoFactorIndex:             data.Get("account_two_factor_index").(string),
+			ConfirmationRequired:              data.Get("confirmation_required").(string),
 			AccountWebAuthnAdd:                data.Get("account_webauthn_add").(string),
 			AccountWebAuthnDelete:             data.Get("account_webauthn_delete").(string),
 			AccountWebAuthnIndex:              data.Get("account_webauthn_index").(string),
@@ -557,6 +565,9 @@ func buildResourceDataFromTheme(t fusionauth.Theme, data *schema.ResourceData) d
 	}
 	if err := data.Set("account_two_factor_index", t.Templates.AccountTwoFactorIndex); err != nil {
 		return diag.Errorf("theme.account_two_factor_index: %s", err.Error())
+	}
+	if err := data.Set("confirmation_required", t.Templates.AccountTwoFactorIndex); err != nil {
+		return diag.Errorf("theme.confirmation_required: %s", err.Error())
 	}
 	if err := data.Set("account_webauthn_add", t.Templates.AccountWebAuthnAdd); err != nil {
 		return diag.Errorf("theme.account_webauthn_add: %s", err.Error())

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gpsinsight/terraform-provider-fusionauth
 go 1.18
 
 require (
-	github.com/FusionAuth/go-client v0.0.0-20230727220333-2d8a30ba4996
+	github.com/FusionAuth/go-client v0.0.0-20240307010310-7a24cf7ce374
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/FusionAuth/go-client v0.0.0-20230313183733-29fd62bc04f7 h1:NQgZJFG6wH
 github.com/FusionAuth/go-client v0.0.0-20230313183733-29fd62bc04f7/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
 github.com/FusionAuth/go-client v0.0.0-20230727220333-2d8a30ba4996 h1:m1BEFfqQRaTUdyxhHXTSBaQWCI22IULsDtObQX+uweU=
 github.com/FusionAuth/go-client v0.0.0-20230727220333-2d8a30ba4996/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
+github.com/FusionAuth/go-client v0.0.0-20240307010310-7a24cf7ce374 h1:F3K7rWZ/8rmCBA7yf6woa3WCgc7w7GUiqxAd6mXB4gI=
+github.com/FusionAuth/go-client v0.0.0-20240307010310-7a24cf7ce374/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=


### PR DESCRIPTION
This PR adds support for Confirmation Required Template that was introduced in 1.49.0 update.
https://fusionauth.io/docs/apis/themes#create-a-theme

This PR unblocks theme updates for versions > 1.49.0