### PR TITLE
Fix wrong reference to Confirmation Required template

### DIFF
--- a/fusionauth/resource_fusionauth_themes.go
+++ b/fusionauth/resource_fusionauth_themes.go
@@ -566,7 +566,7 @@ func buildResourceDataFromTheme(t fusionauth.Theme, data *schema.ResourceData) d
 	if err := data.Set("account_two_factor_index", t.Templates.AccountTwoFactorIndex); err != nil {
 		return diag.Errorf("theme.account_two_factor_index: %s", err.Error())
 	}
-	if err := data.Set("confirmation_required", t.Templates.AccountTwoFactorIndex); err != nil {
+	if err := data.Set("confirmation_required", t.Templates.ConfirmationRequired); err != nil {
 		return diag.Errorf("theme.confirmation_required: %s", err.Error())
 	}
 	if err := data.Set("account_webauthn_add", t.Templates.AccountWebAuthnAdd); err != nil {


### PR DESCRIPTION
## Purpose

This fixes a bug for the template originally introduced in this PR https://github.com/FusionAuth/terraform-provider-fusionauth/pull/263

`confirmation_required` was wrongly referencing the `account_two_factor_index` template and was showing diffs between the wrong templates on plan