### PR TITLE
Update resource_fusionauth_application_helpers.go

### DIFF
--- a/fusionauth/resource_fusionauth_application_helpers.go
+++ b/fusionauth/resource_fusionauth_application_helpers.go
@@ -33,6 +33,12 @@ func buildApplication(data *schema.ResourceData) fusionauth.Application {
 			IdTokenKeyId:                    data.Get("jwt_configuration.0.id_token_key_id").(string),
 			RefreshTokenTimeToLiveInMinutes: data.Get("jwt_configuration.0.refresh_token_ttl_minutes").(int),
 			TimeToLiveInSeconds:             data.Get("jwt_configuration.0.ttl_seconds").(int),
+			RefreshTokenExpirationPolicy: fusionauth.RefreshTokenExpirationPolicy(data.Get("jwt_configuration.0.refresh_token_expiration_policy").(string)),
+			RefreshTokenTimeToLiveInMinutes: data.Get("jwt_configuration.0.refresh_token_time_to_live_in_minutes").(int),
+			RefreshTokenUsagePolicy:         fusionauth.RefreshTokenUsagePolicy(data.Get("jwt_configuration.0.refresh_token_usage_policy").(string)),
+			RefreshTokenSlidingWindowConfiguration: fusionauth.RefreshTokenSlidingWindowConfiguration{
+				MaximumTimeToLiveInMinutes: data.Get("jwt_configuration.0.refresh_token_sliding_window_maximum_time_to_live_in_minutes").(int),
+			},
 		},
 		LambdaConfiguration: fusionauth.LambdaConfiguration{
 			AccessTokenPopulateId:               data.Get("lambda_configuration.0.access_token_populate_id").(string),


### PR DESCRIPTION
Extend the ability to configure application's JWT configuration. Note that currently it seems that `RefreshTokenUsagePolicy` is not supported by the API itself (it is not documented on the Applications API page), so it should be first added to the API, currently the only way to change it on application level seem to be the UI.