### PR TITLE
Fix the login method validation for Google IDP

### DIFF
--- a/fusionauth/resource_fusionauth_idp_google.go
+++ b/fusionauth/resource_fusionauth_idp_google.go
@@ -133,7 +133,7 @@ func newIDPGoogle() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"UsePopup",
 					"UseRedirect",
-					"LinkByEmail",
+					"UseVendorJavaScript",
 				}, false),
 				Description: "The login method to use for this Identity Provider.",
 			},


### PR DESCRIPTION
Replaces `LinkByEmail` with `UseVendorJavaScript`.

Fixes #284