### PR TITLE
Add login intent Id TTL to tenant configuration

### DIFF
--- a/docs/guides/handling_default_resources.md
+++ b/docs/guides/handling_default_resources.md
@@ -33,7 +33,6 @@ resource "fusionauth_tenant" "Default" {
       type   = "randomBytes"
     }
     change_password_id_time_to_live_in_seconds = 600
-    completion_token_time_to_live_in_seconds   = 1800
     device_code_time_to_live_in_seconds        = 300
     device_user_code_id_generator {
       length = 6
@@ -49,6 +48,7 @@ resource "fusionauth_tenant" "Default" {
       type   = "randomAlphaNumeric"
     }
     external_authentication_id_time_to_live_in_seconds = 300
+    login_intent_time_to_live_in_seconds               = 1800
     one_time_password_time_to_live_in_seconds          = 60
     passwordless_login_generator {
       length = 32

--- a/docs/guides/handling_default_resources.md
+++ b/docs/guides/handling_default_resources.md
@@ -33,6 +33,7 @@ resource "fusionauth_tenant" "Default" {
       type   = "randomBytes"
     }
     change_password_id_time_to_live_in_seconds = 600
+    completion_token_time_to_live_in_seconds   = 1800
     device_code_time_to_live_in_seconds        = 300
     device_user_code_id_generator {
       length = 6

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -287,7 +287,6 @@ resource "fusionauth_tenant" "example" {
       type   = "randomBytes"
     }
     change_password_id_time_to_live_in_seconds = 600
-    completion_token_time_to_live_in_seconds   = 1800
     device_code_time_to_live_in_seconds        = 1800
     device_user_code_id_generator {
       length = 6
@@ -303,6 +302,7 @@ resource "fusionauth_tenant" "example" {
       type   = "randomAlphaNumeric"
     }
     external_authentication_id_time_to_live_in_seconds = 300
+    login_intent_time_to_live_in_seconds               = 1800
     one_time_password_time_to_live_in_seconds          = 60
     passwordless_login_generator {
       length = 32

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -287,6 +287,7 @@ resource "fusionauth_tenant" "example" {
       type   = "randomBytes"
     }
     change_password_id_time_to_live_in_seconds = 600
+    completion_token_time_to_live_in_seconds   = 1800
     device_code_time_to_live_in_seconds        = 1800
     device_user_code_id_generator {
       length = 6

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -996,6 +996,12 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 				Description:  "The time in seconds until a change password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
+			"completion_token_time_to_live_in_seconds": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				Description:  "The number of seconds before the Completion Token identifier is no longer valid to complete post-authentication steps in the OAuth workflow. Must be greater than 0.",
+				ValidateFunc: validation.IntAtLeast(1),
+			},
 			"device_code_time_to_live_in_seconds": {
 				Type:         schema.TypeInt,
 				Required:     true,

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -996,12 +996,6 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 				Description:  "The time in seconds until a change password Id is no longer valid and cannot be used by the Change Password API. Value must be greater than 0.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
-			"completion_token_time_to_live_in_seconds": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				Description:  "The number of seconds before the Completion Token identifier is no longer valid to complete post-authentication steps in the OAuth workflow. Must be greater than 0.",
-				ValidateFunc: validation.IntAtLeast(1),
-			},
 			"device_code_time_to_live_in_seconds": {
 				Type:         schema.TypeInt,
 				Required:     true,
@@ -1079,6 +1073,12 @@ func newExternalIdentifierConfiguration() *schema.Resource {
 				Type:         schema.TypeInt,
 				Required:     true,
 				Description:  "The time in seconds until an external authentication Id is no longer valid and cannot be used by the Token API. Value must be greater than 0.",
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"login_intent_time_to_live_in_seconds": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				Description:  "The number of seconds before the Login Timeout identifier is no longer valid to complete post-authentication steps in the OAuth workflow. Must be greater than 0.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"one_time_password_time_to_live_in_seconds": {

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -58,7 +58,7 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 				"external_identifier_configuration.0.change_password_id_time_to_live_in_seconds",
 			).(int),
 			CompletionTokenTimeToLiveInSeconds: data.Get(
-				"external_identifier_configuration.0.completion_token_time_to_live_in_seconds"
+				"external_identifier_configuration.0.completion_token_time_to_live_in_seconds",
 			).(int),
 			DeviceCodeTimeToLiveInSeconds: data.Get(
 				"external_identifier_configuration.0.device_code_time_to_live_in_seconds",

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -57,6 +57,9 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			ChangePasswordIdTimeToLiveInSeconds: data.Get(
 				"external_identifier_configuration.0.change_password_id_time_to_live_in_seconds",
 			).(int),
+			CompletionTokenTimeToLiveInSeconds: data.Get(
+				"external_identifier_configuration.0.completion_token_time_to_live_in_seconds"
+			)
 			DeviceCodeTimeToLiveInSeconds: data.Get(
 				"external_identifier_configuration.0.device_code_time_to_live_in_seconds",
 			).(int),
@@ -478,6 +481,7 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 				"type":   t.ExternalIdentifierConfiguration.ChangePasswordIdGenerator.Type,
 			}},
 			"change_password_id_time_to_live_in_seconds": t.ExternalIdentifierConfiguration.ChangePasswordIdTimeToLiveInSeconds,
+			"completion_token_time_to_live_in_seconds":   t.ExternalIdentifierConfiguration.CompletionTokenTimeToLiveInSeconds,
 			"device_code_time_to_live_in_seconds":        t.ExternalIdentifierConfiguration.DeviceCodeTimeToLiveInSeconds,
 			"device_user_code_id_generator": []map[string]interface{}{{
 				"length": t.ExternalIdentifierConfiguration.DeviceUserCodeIdGenerator.Length,

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -57,9 +57,6 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			ChangePasswordIdTimeToLiveInSeconds: data.Get(
 				"external_identifier_configuration.0.change_password_id_time_to_live_in_seconds",
 			).(int),
-			CompletionTokenTimeToLiveInSeconds: data.Get(
-				"external_identifier_configuration.0.completion_token_time_to_live_in_seconds",
-			).(int),
 			DeviceCodeTimeToLiveInSeconds: data.Get(
 				"external_identifier_configuration.0.device_code_time_to_live_in_seconds",
 			).(int),
@@ -80,6 +77,9 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			).(int),
 			ExternalAuthenticationIdTimeToLiveInSeconds: data.Get(
 				"external_identifier_configuration.0.external_authentication_id_time_to_live_in_seconds",
+			).(int),
+			LoginIntentTimeToLiveInSeconds: data.Get(
+				"external_identifier_configuration.0.login_intent_time_to_live_in_seconds",
 			).(int),
 			OneTimePasswordTimeToLiveInSeconds: data.Get(
 				"external_identifier_configuration.0.one_time_password_time_to_live_in_seconds",
@@ -481,7 +481,6 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 				"type":   t.ExternalIdentifierConfiguration.ChangePasswordIdGenerator.Type,
 			}},
 			"change_password_id_time_to_live_in_seconds": t.ExternalIdentifierConfiguration.ChangePasswordIdTimeToLiveInSeconds,
-			"completion_token_time_to_live_in_seconds":   t.ExternalIdentifierConfiguration.CompletionTokenTimeToLiveInSeconds,
 			"device_code_time_to_live_in_seconds":        t.ExternalIdentifierConfiguration.DeviceCodeTimeToLiveInSeconds,
 			"device_user_code_id_generator": []map[string]interface{}{{
 				"length": t.ExternalIdentifierConfiguration.DeviceUserCodeIdGenerator.Length,
@@ -493,6 +492,7 @@ func buildResourceDataFromTenant(t fusionauth.Tenant, data *schema.ResourceData)
 			}},
 			"email_verification_id_time_to_live_in_seconds":      t.ExternalIdentifierConfiguration.EmailVerificationIdTimeToLiveInSeconds,
 			"external_authentication_id_time_to_live_in_seconds": t.ExternalIdentifierConfiguration.ExternalAuthenticationIdTimeToLiveInSeconds,
+			"login_intent_time_to_live_in_seconds":               t.ExternalIdentifierConfiguration.LoginIntentTimeToLiveInSeconds,
 			"one_time_password_time_to_live_in_seconds":          t.ExternalIdentifierConfiguration.OneTimePasswordTimeToLiveInSeconds,
 			"passwordless_login_generator": []map[string]interface{}{{
 				"length": t.ExternalIdentifierConfiguration.PasswordlessLoginGenerator.Length,

--- a/fusionauth/resource_fusionauth_tenant_helpers.go
+++ b/fusionauth/resource_fusionauth_tenant_helpers.go
@@ -59,7 +59,7 @@ func buildTenant(data *schema.ResourceData) (fusionauth.Tenant, diag.Diagnostics
 			).(int),
 			CompletionTokenTimeToLiveInSeconds: data.Get(
 				"external_identifier_configuration.0.completion_token_time_to_live_in_seconds"
-			)
+			).(int),
 			DeviceCodeTimeToLiveInSeconds: data.Get(
 				"external_identifier_configuration.0.device_code_time_to_live_in_seconds",
 			).(int),

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -139,6 +139,7 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.change_password_id_generator.0.length", "32"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.change_password_id_generator.0.type", "randomBytes"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.change_password_id_time_to_live_in_seconds", "600"),
+		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.completion_token_time_to_live_in_seconds", "3600"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.device_code_time_to_live_in_seconds", "1800"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.device_user_code_id_generator.0.length", "6"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.device_user_code_id_generator.0.type", "randomAlphaNumeric"),
@@ -519,6 +520,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
       type   = "randomBytes"
     }
     change_password_id_time_to_live_in_seconds = 600
+    completion_token_time_to_live_in_seconds   = 3600
     device_code_time_to_live_in_seconds        = 1800
     device_user_code_id_generator {
       length = 6

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -139,7 +139,6 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.change_password_id_generator.0.length", "32"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.change_password_id_generator.0.type", "randomBytes"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.change_password_id_time_to_live_in_seconds", "600"),
-		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.completion_token_time_to_live_in_seconds", "3600"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.device_code_time_to_live_in_seconds", "1800"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.device_user_code_id_generator.0.length", "6"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.device_user_code_id_generator.0.type", "randomAlphaNumeric"),
@@ -149,6 +148,7 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.email_verification_one_time_code_generator.0.type", "randomAlphaNumeric"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.email_verification_id_time_to_live_in_seconds", "86400"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.external_authentication_id_time_to_live_in_seconds", "300"),
+		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.login_intent_time_to_live_in_seconds", "3600"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.one_time_password_time_to_live_in_seconds", "60"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.passwordless_login_generator.0.length", "32"),
 		resource.TestCheckResourceAttr(tfResourcePath, "external_identifier_configuration.0.passwordless_login_generator.0.type", "randomBytes"),
@@ -520,7 +520,6 @@ resource "fusionauth_tenant" "test_%[1]s" {
       type   = "randomBytes"
     }
     change_password_id_time_to_live_in_seconds = 600
-    completion_token_time_to_live_in_seconds   = 3600
     device_code_time_to_live_in_seconds        = 1800
     device_user_code_id_generator {
       length = 6
@@ -536,6 +535,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
     }
     email_verification_id_time_to_live_in_seconds      = 86400
     external_authentication_id_time_to_live_in_seconds = 300
+		login_intent_time_to_live_in_seconds		   				= 3600
     one_time_password_time_to_live_in_seconds          = 60
     passwordless_login_generator {
       length = 32

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -535,7 +535,7 @@ resource "fusionauth_tenant" "test_%[1]s" {
     }
     email_verification_id_time_to_live_in_seconds      = 86400
     external_authentication_id_time_to_live_in_seconds = 300
-		login_intent_time_to_live_in_seconds		   				= 3600
+    login_intent_time_to_live_in_seconds               = 3600
     one_time_password_time_to_live_in_seconds          = 60
     passwordless_login_generator {
       length = 32

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gpsinsight/terraform-provider-fusionauth
 go 1.20
 
 require (
-	github.com/FusionAuth/go-client v0.0.0-20240425220342-2317e10dfcf5
+	github.com/FusionAuth/go-client v0.0.0-20240912225700-ce40548e5bef
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
-github.com/FusionAuth/go-client v0.0.0-20240425220342-2317e10dfcf5 h1:GGDFaOr/r7FTXZj4wrgtW4LlXeTFuBVoWgzuW4cbQ+s=
-github.com/FusionAuth/go-client v0.0.0-20240425220342-2317e10dfcf5/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
 github.com/FusionAuth/go-client v0.0.0-20240912225700-ce40548e5bef h1:BRn4829CZpFBMp9afGlru7+9p/4U1m7ELhghd6vcRWg=
 github.com/FusionAuth/go-client v0.0.0-20240912225700-ce40548e5bef/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 github.com/FusionAuth/go-client v0.0.0-20240425220342-2317e10dfcf5 h1:GGDFaOr/r7FTXZj4wrgtW4LlXeTFuBVoWgzuW4cbQ+s=
 github.com/FusionAuth/go-client v0.0.0-20240425220342-2317e10dfcf5/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
+github.com/FusionAuth/go-client v0.0.0-20240912225700-ce40548e5bef h1:BRn4829CZpFBMp9afGlru7+9p/4U1m7ELhghd6vcRWg=
+github.com/FusionAuth/go-client v0.0.0-20240912225700-ce40548e5bef/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=


### PR DESCRIPTION
### Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/2736
- https://linear.app/fusionauth/issue/ENG-988/[bug]-cannot-log-in-anymore-after-upgrade-to-v150x

### Changes
Add `login_intent_time_to_live_in_seconds` external identifier configuration for the tenant.

### Depends on
- https://github.com/FusionAuth/fusionauth-app/pull/452
- https://github.com/FusionAuth/fusionauth-client-builder/pull/89