### PR TITLE
Support tenant webhookids

### DIFF
--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -440,8 +440,9 @@ resource "fusionauth_tenant" "example" {
 
 ## Argument Reference
 * `source_tenant_id` - (Optional) The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.
+* `webhook_ids` - (Optional) An array of Webhook Ids. For Webhooks that are not already configured for All Tenants, specifying an Id on this request will indicate the associated Webhook should handle events for this tenant.
 * `tenant_id` - (Optional) The Id to use for the new Tenant. If not specified a secure random UUID will be generated.
-* `access_control_configuration` - (Optiona)
+* `access_control_configuration` - (Optional)
     - `ui_ip_access_control_list_id` - (Optional) The Id of the IP Access Control List limiting access to all applications in this tenant.
 * `captcha_configuration` - (Optional)
     - `enabled` - (Optional) Whether captcha configuration is enabled.

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -19,6 +19,12 @@ func newTenant() *schema.Resource {
 				Description:  "The optional Id of an existing Tenant to make a copy of. If present, the tenant.id and tenant.name values of the request body will be applied to the new Tenant, all other values will be copied from the source Tenant to the new Tenant.",
 				ValidateFunc: validation.IsUUID,
 			},
+			"webhook_ids": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "An array of Webhook Ids. For Webhooks that are not already configured for All Tenants, specifying an Id on this request will indicate the associated Webhook should handle events for this tenant.",
+			},
 			"tenant_id": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/fusionauth/resource_fusionauth_tenant_crud.go
+++ b/fusionauth/resource_fusionauth_tenant_crud.go
@@ -19,6 +19,7 @@ func createTenant(_ context.Context, data *schema.ResourceData, i interface{}) d
 	t := fusionauth.TenantRequest{
 		Tenant:         tenant,
 		SourceTenantId: data.Get("source_tenant_id").(string),
+		WebhookIds:     handleStringSlice("webhook_ids", data),
 	}
 	client.FAClient.TenantId = ""
 
@@ -69,6 +70,7 @@ func updateTenant(_ context.Context, data *schema.ResourceData, i interface{}) d
 	t := fusionauth.TenantRequest{
 		Tenant:         tenant,
 		SourceTenantId: data.Get("source_tenant_id").(string),
+		WebhookIds:     handleStringSlice("webhook_ids", data),
 	}
 
 	resp, faErrs, err := client.FAClient.UpdateTenant(data.Id(), t)


### PR DESCRIPTION
## Purpose

Fix https://github.com/FusionAuth/terraform-provider-fusionauth/issues/257

## Approach

Tenant API requests for [POST](https://fusionauth.io/docs/apis/tenants#request) and [PUT](https://fusionauth.io/docs/apis/tenants#request-3), support `webhookIds` to link webhooks to tenants

## Caveats
Tenant [GET](https://fusionauth.io/docs/apis/tenants#response-1), [POST](https://fusionauth.io/docs/apis/tenants#response) and [PUT](https://fusionauth.io/docs/apis/tenants#response-3) responses do not return `webhookIds`, so we're unable to see a diff based on remote state.
