### PR TITLE
Add webhook event log retention policy configuration

### DIFF
--- a/docs/resources/system_configuration.md
+++ b/docs/resources/system_configuration.md
@@ -45,3 +45,7 @@ resource "fusionauth_system_configuration" "example" {
     - `header_color` - (Optional) A hexadecimal color to override the default menu color in the user interface.
     - `logo_url` - (Optional) A URL of a logo to override the default FusionAuth logo in the user interface.
     - `menu_font_color` - (Optional) A hexadecimal color to override the default menu font color in the user interface.
+* `webhook_event_log_configuration` - (Optional)
+    - `delete` - (Optional)
+        * `enabled` - (Optional) Whether or not FusionAuth should delete the webhook event logs based upon this configuration. When true the webhookEventLogConfiguration.delete.numberOfDaysToRetain will be used to identify webhook event logs that are eligible for deletion. When this value is set to false webhook event logs will be preserved forever.
+        * `number_of_days_to_retain` - (Optional) The number of days to retain webhook event logs.

--- a/fusionauth/resource_system_configuration.go
+++ b/fusionauth/resource_system_configuration.go
@@ -479,6 +479,13 @@ func getDefaultSystemConfigurationRequest() fusionauth.SystemConfigurationReques
 				},
 			},
 			ReportTimezone: "America/Denver",
+			WebhookEventLogConfiguration: fusionauth.WebhookEventLogConfiguration{
+				Delete: fusionauth.DeleteConfiguration{
+					Enableable: fusionauth.Enableable{
+						Enabled: false,
+					},
+				},
+			},
 		},
 	}
 }

--- a/fusionauth/resource_system_configuration.go
+++ b/fusionauth/resource_system_configuration.go
@@ -187,6 +187,39 @@ func resourceSystemConfiguration() *schema.Resource {
 					},
 				},
 			},
+			"webhook_event_log_configuration": {
+				Type:       schema.TypeList,
+				MaxItems:   1,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"delete": {
+							Type:       schema.TypeList,
+							MaxItems:   1,
+							Optional:   true,
+							ConfigMode: schema.SchemaConfigModeAttr,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     false,
+										Description: "Whether or not FusionAuth should delete the webhook event logs based upon this configuration. When true the webhookEventLogConfiguration.delete.numberOfDaysToRetain will be used to identify webhook event logs that are eligible for deletion. When this value is set to false webhook event logs will be preserved forever.",
+									},
+									"number_of_days_to_retain": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Default:     365,
+										Description: "The number of days to retain webhook event logs.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -304,6 +337,13 @@ func buildSystemConfigurationRequest(data *schema.ResourceData) fusionauth.Syste
 		sc.SystemConfiguration.UiConfiguration.MenuFontColor = v.(string)
 	}
 
+	if v, ok := data.GetOk("webhook_event_log_configuration.0.delete.0.enabled"); ok {
+		sc.SystemConfiguration.WebhookEventLogConfiguration.Delete.Enabled = v.(bool)
+	}
+	if v, ok := data.GetOk("webhook_event_log_configuration.0.delete.0.number_of_days_to_retain"); ok {
+		sc.SystemConfiguration.WebhookEventLogConfiguration.Delete.NumberOfDaysToRetain = v.(int)
+	}
+
 	return sc
 }
 
@@ -373,6 +413,20 @@ func buildResourceFromSystemConfiguration(sc fusionauth.SystemConfiguration, dat
 	})
 	if err != nil {
 		return diag.Errorf("system_configuration.ui_configuration: %s", err.Error())
+	}
+
+	err = data.Set("webhook_event_log_configuration", []map[string]interface{}{
+		{
+			"delete": []map[string]interface{}{
+				{
+					"enabled":                  sc.WebhookEventLogConfiguration.Delete.Enabled,
+					"number_of_days_to_retain": sc.WebhookEventLogConfiguration.Delete.NumberOfDaysToRetain,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return diag.Errorf("system_configuration.webhook_event_log_configuration: %s", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
### Issue
- https://github.com/FusionAuth/fusionauth-issues/issues/1314
- https://linear.app/fusionauth/issue/ENG-175/add-a-webhook-event-log

### Changes
Add `webhook_event_log_configuration` to system configuration.

### Depends on
- https://github.com/FusionAuth/fusionauth-app/pull/436
- https://github.com/FusionAuth/fusionauth-client-builder/pull/83