### PR TITLE
Add webauthn support

### DIFF
--- a/fusionauth/resource_fusionauth_application.go
+++ b/fusionauth/resource_fusionauth_application.go
@@ -309,6 +309,13 @@ func newApplication() *schema.Resource {
 				Default:     false,
 				Description: "Whether or not registrations to this Application may be verified. When this is set to true the verificationEmailTemplateId parameter is also required.",
 			},
+			"webauthn_configuration": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				Elem:     newApplicationWebAuthNConfiguration(),
+			},
 			"email_configuration": {
 				Type:       schema.TypeList,
 				MaxItems:   1,
@@ -736,6 +743,51 @@ func newOAuthConfiguration() *schema.Resource {
 					fusionauth.UnknownScopePolicy_Remove.String(),
 					fusionauth.UnknownScopePolicy_Reject.String(),
 				}, false),
+			},
+		},
+	}
+}
+
+func newApplicationWebAuthNConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"bootstrap_workflow": {
+				Type:       schema.TypeList,
+				MaxItems:   1,
+				Optional:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Whether the WebAuthn bootstrap workflow is enabled for this application. This overrides the tenant configuration. Has no effect if application.webAuthnConfiguration.enabled is false.",
+						},
+					},
+				},
+			},
+			"reauthentication_workflow": {
+				Type:       schema.TypeList,
+				MaxItems:   1,
+				Optional:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Whether the WebAuthn reauthentication workflow is enabled for this application. This overrides the tenant configuration. Has no effect if application.webAuthnConfiguration.enabled is false.",
+						},
+					},
+				},
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Indicates if this application enables WebAuthn workflows based on the configuration defined here or the Tenant WebAuthn configuration. If this is false, WebAuthn workflows are enabled based on the Tenant configuration. If true, WebAuthn workflows are enabled according to the configuration of this application.",
 			},
 		},
 	}

--- a/fusionauth/resource_fusionauth_application_helpers.go
+++ b/fusionauth/resource_fusionauth_application_helpers.go
@@ -61,6 +61,15 @@ func buildApplication(data *schema.ResourceData) fusionauth.Application {
 			},
 			TrustPolicy: fusionauth.ApplicationMultiFactorTrustPolicy(data.Get("multi_factor_configuration.0.trust_policy").(string)),
 		},
+		WebAuthnConfiguration: fusionauth.ApplicationWebAuthnConfiguration{
+			Enableable: buildEnableable("webauthn_configuration.0.enabled", data),
+			BootstrapWorkflow: fusionauth.ApplicationWebAuthnWorkflowConfiguration{
+				Enableable: buildEnableable("webauthn_configuration.0.bootstrap_workflow.0.enabled", data),
+			},
+			ReauthenticationWorkflow: fusionauth.ApplicationWebAuthnWorkflowConfiguration{
+				Enableable: buildEnableable("webauthn_configuration.0.reauthentication_workflow.0.enabled", data),
+			},
+		},
 		Name: data.Get("name").(string),
 		OauthConfiguration: fusionauth.OAuth2Configuration{
 			AuthorizedOriginURLs:          handleStringSlice("oauth_configuration.0.authorized_origin_urls", data),
@@ -289,6 +298,22 @@ func buildResourceDataFromApplication(a fusionauth.Application, data *schema.Res
 	})
 	if err != nil {
 		return diag.Errorf("application.multi_factor_configuration: %s", err.Error())
+	}
+
+	err = data.Set("webauthn_configuration", []map[string]interface{}{
+		{
+			"enabled": a.WebAuthnConfiguration.Enabled,
+			"bootstrap_workflow": []map[string]interface{}{{
+				"enabled": a.WebAuthnConfiguration.BootstrapWorkflow.Enabled,
+			}},
+			"reauthentication_workflow": []map[string]interface{}{{
+				"enabled": a.WebAuthnConfiguration.ReauthenticationWorkflow.Enabled,
+			}},
+		},
+	})
+
+	if err != nil {
+		return diag.Errorf("application.webauthn_configuration: %s", err.Error())
 	}
 
 	if err := data.Set("name", a.Name); err != nil {

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -988,7 +988,7 @@ func newTenantWebAuthNConfiguration() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,
-							Description: "Whether the WebAuthn bootstrap workflow is enabled for this application. This overrides the tenant configuration. Has no effect if application.webAuthnConfiguration.enabled is false.",
+							Description: "Whether or not this tenant has the WebAuthn bootstrap workflow enabled. The bootstrap workflow is used when the user must “bootstrap” the authentication process by identifying themselves prior to the WebAuthn ceremony and can be used to authenticate from a new device using WebAuthn.",
 						},
 						"authenticator_attachment_preference": {
 							Type:     schema.TypeString,
@@ -1026,7 +1026,7 @@ func newTenantWebAuthNConfiguration() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,
-							Description: "Whether the WebAuthn reauthentication workflow is enabled for this application. This overrides the tenant configuration. Has no effect if application.webAuthnConfiguration.enabled is false.",
+							Description: "Whether or not this tenant has the WebAuthn reauthentication workflow enabled. The reauthentication workflow will automatically prompt a user to authenticate using WebAuthn for repeated logins from the same device.",
 						},
 						"authenticator_attachment_preference": {
 							Type:     schema.TypeString,
@@ -1057,7 +1057,7 @@ func newTenantWebAuthNConfiguration() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Indicates if this application enables WebAuthn workflows based on the configuration defined here or the Tenant WebAuthn configuration. If this is false, WebAuthn workflows are enabled based on the Tenant configuration. If true, WebAuthn workflows are enabled according to the configuration of this application.",
+				Description: "Whether or not this tenant has WebAuthn enabled globally.",
 			},
 			"debug": {
 				Type:        schema.TypeBool,

--- a/fusionauth/resource_fusionauth_tenant.go
+++ b/fusionauth/resource_fusionauth_tenant.go
@@ -819,6 +819,13 @@ func newTenant() *schema.Resource {
 					},
 				},
 			},
+			"webauthn_configuration": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				Elem:     newTenantWebAuthNConfiguration(),
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -962,6 +969,113 @@ func newFailedAuthenticationConfiguration() *schema.Resource {
 				Optional:     true,
 				Description:  "The Id of the User Action that is applied when the threshold is reached for too many failed authentication attempts.",
 				ValidateFunc: validation.IsUUID,
+			},
+		},
+	}
+}
+
+func newTenantWebAuthNConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"bootstrap_workflow": {
+				Type:       schema.TypeList,
+				MaxItems:   1,
+				Optional:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Whether the WebAuthn bootstrap workflow is enabled for this application. This overrides the tenant configuration. Has no effect if application.webAuthnConfiguration.enabled is false.",
+						},
+						"authenticator_attachment_preference": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "any",
+							ValidateFunc: validation.StringInSlice([]string{
+								"any",
+								"crossPlatform",
+								"platform",
+							}, false),
+							Description: "Determines the authenticator attachment requirement for WebAuthn passkey registration when using the bootstrap workflow.",
+						},
+						"user_verification_requirement": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "required",
+							ValidateFunc: validation.StringInSlice([]string{
+								"discouraged",
+								"preferred",
+								"required",
+							}, false),
+							Description: "Determines the user verification requirement for WebAuthn passkey registration and authentication when using the bootstrap workflow.",
+						},
+					},
+				},
+			},
+			"reauthentication_workflow": {
+				Type:       schema.TypeList,
+				MaxItems:   1,
+				Optional:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Whether the WebAuthn reauthentication workflow is enabled for this application. This overrides the tenant configuration. Has no effect if application.webAuthnConfiguration.enabled is false.",
+						},
+						"authenticator_attachment_preference": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "platform",
+							ValidateFunc: validation.StringInSlice([]string{
+								"any",
+								"crossPlatform",
+								"platform",
+							}, false),
+							Description: "Determines the authenticator attachment requirement for WebAuthn passkey registration when using the reauthentication workflow.",
+						},
+						"user_verification_requirement": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "required",
+							ValidateFunc: validation.StringInSlice([]string{
+								"discouraged",
+								"preferred",
+								"required",
+							}, false),
+							Description: "Determines the user verification requirement for WebAuthn passkey registration and authentication when using the reauthentication workflow.",
+						},
+					},
+				},
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Indicates if this application enables WebAuthn workflows based on the configuration defined here or the Tenant WebAuthn configuration. If this is false, WebAuthn workflows are enabled based on the Tenant configuration. If true, WebAuthn workflows are enabled according to the configuration of this application.",
+			},
+			"debug": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Determines if debug should be enabled for this tenant to create an event log to assist in debugging WebAuthn errors.",
+			},
+			"relaying_party_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "The value this tenant will use for the Relying Party Id in WebAuthn ceremonies. Passkeys can only be used to authenticate on sites using the same Relying Party Id they were registered with. This value must match the browser origin or be a registrable domain suffix of the browser origin.",
+			},
+			"relaying_party_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "The value this tenant will use for the Relying Party name in WebAuthn ceremonies. This value may be displayed by browser or operating system dialogs during WebAuthn ceremonies.",
 			},
 		},
 	}

--- a/fusionauth/resource_fusionauth_tenant_test.go
+++ b/fusionauth/resource_fusionauth_tenant_test.go
@@ -292,6 +292,9 @@ func testTenantAccTestCheckFuncs(
 		resource.TestCheckResourceAttr(tfResourcePath, "username_configuration.0.unique.0.number_of_digits", "8"),
 		resource.TestCheckResourceAttr(tfResourcePath, "username_configuration.0.unique.0.separator", "_"),
 		resource.TestCheckResourceAttr(tfResourcePath, "username_configuration.0.unique.0.strategy", "Always"),
+
+		// webauthn_configuration
+		resource.TestCheckResourceAttr(tfResourcePath, "webauthn_configuration.0.unique.0.enabled", "false"),
 	)
 }
 
@@ -706,6 +709,22 @@ resource "fusionauth_tenant" "test_%[1]s" {
       separator        = "_"
       strategy         = "Always"
     }
+  }
+  webauthn_configuration {
+	enabled			    = false
+	debug			    = false
+	relaying_party_id   = "auth.piedpiper.com"
+    relaying_party_name = "Pied Piper"
+	bootstrap_workflow {
+      enabled		    = false
+      authenticator_attachment_preference 	= "any"
+	  user_verification_requirement 		= "required"
+	}
+	reauthentication_workflow {
+	  enabled		   = false
+      authenticator_attachment_preference 	= "platform"
+      user_verification_requirement 		= "required"
+	}
   }
 }
 `,

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/gpsinsight/terraform-provider-fusionauth
 
-go 1.21
-
-toolchain go1.22.4
+go 1.20
 
 require (
 	github.com/FusionAuth/go-client v0.0.0-20240425220342-2317e10dfcf5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/gpsinsight/terraform-provider-fusionauth
 
-go 1.20
+go 1.21
+
+toolchain go1.22.4
 
 require (
 	github.com/FusionAuth/go-client v0.0.0-20240425220342-2317e10dfcf5


### PR DESCRIPTION
This adds support for webauthn for both the tenant and application.

Note: I have zero go experience. I tried to run the tests based on the README, but I get the following issues locally:

```
=== RUN   TestAccFusionauthTenant_basic
    resource_fusionauth_tenant_test.go:30: Step 1/3 error: Error running apply: exit status 1
        
        Error: unexpected status code: 400(Bad Request) Errors: theme.defaultMessages: You must specify all the required keys in the [theme.defaultMessages] property. It is missing these keys: customize. You may optionally use these default values:
        customize=Customize
        
          with fusionauth_theme.test_lmzavincgl,
          on terraform_plugin_test.tf line 17, in resource "fusionauth_theme" "test_lmzavincgl":
          17: resource "fusionauth_theme" "test_lmzavincgl" {
```

Would really appreciate if someone can modify my PR to fix any issues.