### PR TITLE
Fix minor typo in documentation - s/TThe/the/g

### DIFF
--- a/docs/resources/idp_external_jwt.md
+++ b/docs/resources/idp_external_jwt.md
@@ -41,7 +41,7 @@ resource "fusionauth_idp_external_jwt" "jwt" {
 * `lambda_reconcile_id` - (Optional) The unique Id of the lambda to used during the user reconcile process to map custom claims from the external identity provider to the FusionAuth user.
 * `name` - (Required) The name of the Identity Provider.
 * `oauth2_authorization_endpoint` - (Optional) The authorization endpoint for this Identity Provider. This value is not utilized by FusionAuth is only provided to be returned by the Lookup Identity Provider API response. During integration you may then utilize this value to perform the browser redirect to the OAuth2 authorize endpoint.
-* `oauth2_token_endpoint` - (Optional) TThe token endpoint for this Identity Provider. This value is not utilized by FusionAuth is only provided to be returned by the Lookup Identity Provider API response. During integration you may then utilize this value to complete the OAuth2 grant workflow.
+* `oauth2_token_endpoint` - (Optional) The token endpoint for this Identity Provider. This value is not utilized by FusionAuth is only provided to be returned by the Lookup Identity Provider API response. During integration you may then utilize this value to complete the OAuth2 grant workflow.
 * `unique_identity_claim` - (Required) The name of the claim that represents the unique identify of the User. This will generally be email or the name of the claim that provides the email address.
 * `linking_strategy` - (Optional) The linking strategy to use when creating the link between the {idp_display_name} Identity Provider and the user.
 * `tenant_configuration` - (Optional) The configuration for each Tenant that limits the number of links a user may have for a particular identity provider.

--- a/docs/resources/idp_saml_v2.md
+++ b/docs/resources/idp_saml_v2.md
@@ -53,7 +53,7 @@ resource "fusionauth_idp_saml_v2" "Saml" {
 * `name` - (Required) The name of this OpenID Connect identity provider. This is only used for display purposes.
 * `name_id_format` - (Optional) Either urn:oasis:names:tc:SAML:2.0:nameid-format:persistent or urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress depending on which NameId format you wish to use.
 * `post_request` - (Optional) When true the authentication request will use the HTTP POST binding with the identity provider instead of the default Redirect binding which uses the HTTP GET method.
-* `request_signing_key` - (Optional) TThe key pair Id to use to sign the SAML request. Required when `sign_request` is true.
+* `request_signing_key` - (Optional) The key pair Id to use to sign the SAML request. Required when `sign_request` is true.
 * `sign_request` - (Optional) When true authentication requests sent to the identity provider will be signed.
 * `use_name_for_email` - (Optional) Whether or not FusionAuth will use the NameID element value as the email address of the user for reconciliation processing. If this is false, then the `email_claim` property must be set.
 * `xml_signature_canonicalization_method` - (Optional) The XML signature canonicalization method used when digesting and signing the SAML request.

--- a/docs/resources/idp_twitch.md
+++ b/docs/resources/idp_twitch.md
@@ -36,7 +36,7 @@ resource "fusionauth_idp_twitch" "twitch" {
     - `enabled` - (Optional) Determines if this identity provider is enabled for the Application specified by the applicationId key.
     - `scope` - (Optional)This is an optional Application specific override for the top level scope.
 * `button_text` - (Required) The top-level button text to use on the FusionAuth login page for this Identity Provider.
-* `client_id` - (Required) TThe top-level Xbox client id for your Application. This value is retrieved from the Xbox developer website when you setup your Xbox developer account.
+* `client_id` - (Required) The top-level Xbox client id for your Application. This value is retrieved from the Xbox developer website when you setup your Xbox developer account.
 * `client_secret` - (Required) The top-level client secret to use with the Xbox Identity Provider when retrieving the long-lived token. This value is retrieved from the Xbox developer website when you setup your Xbox developer account.
 * `debug` - (Optional) Determines if debug is enabled for this provider. When enabled, each time this provider is invoked to reconcile a login an Event Log will be created.
 * `enabled` - (Optional) Determines if this provider is enabled. If it is false then it will be disabled globally.

--- a/docs/resources/idp_xbox.md
+++ b/docs/resources/idp_xbox.md
@@ -38,7 +38,7 @@ resource "fusionauth_idp_xbox" "xbox" {
     - `enabled` - (Optional) Determines if this identity provider is enabled for the Application specified by the applicationId key.
     - `scope` - (Optional)This is an optional Application specific override for the top level scope.
 * `button_text` - (Required) The top-level button text to use on the FusionAuth login page for this Identity Provider.
-* `client_id` - (Required) TThe top-level Xbox client id for your Application. This value is retrieved from the Xbox developer website when you setup your Xbox developer account.
+* `client_id` - (Required) The top-level Xbox client id for your Application. This value is retrieved from the Xbox developer website when you setup your Xbox developer account.
 * `client_secret` - (Required) The top-level client secret to use with the Xbox Identity Provider when retrieving the long-lived token. This value is retrieved from the Xbox developer website when you setup your Xbox developer account.
 * `debug` - (Optional) Determines if debug is enabled for this provider. When enabled, each time this provider is invoked to reconcile a login an Event Log will be created.
 * `enabled` - (Optional) Determines if this provider is enabled. If it is false then it will be disabled globally.

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -532,7 +532,7 @@ resource "fusionauth_tenant" "example" {
     - `two_factor_one_time_code_id_time_to_live_in_seconds` - (Optional) The number of seconds before the Two-Factor One Time Code used to enable or disable a two-factor method is no longer valid. Must be greater than 0.
     - `two_factor_trust_id_time_to_live_in_seconds` - (Required) The time in seconds until an issued Two Factor trust Id is no longer valid and the User will be required to complete Two Factor authentication during the next authentication attempt. Value must be greater than 0.
     - `two_factor_one_time_code_id_generator` - (Required)
-        - `length` - (Required) TThe length of the secure generator used for generating the the two factor code Id.
+        - `length` - (Required) The length of the secure generator used for generating the the two factor code Id.
         - `type` - (Optional) The type of the secure generator used for generating the two factor one time code Id.
 * `failed_authentication_configuration` - (Optional)
     - `action_duration` - (Required) The duration of the User Action. This value along with the actionDurationUnit will be used to set the duration of the User Action. Value must be greater than 0.


### PR DESCRIPTION
Just a minor typo, not a functional change.