### PR TITLE
feat: add permission for application search endpoint

### DIFF
--- a/fusionauth/resource_fusionauth_api_key.go
+++ b/fusionauth/resource_fusionauth_api_key.go
@@ -63,6 +63,7 @@ func resourceAPIKey() *schema.Resource {
 								"/api/application",
 								"/api/application/oauth-configuration",
 								"/api/application/role",
+								"/api/application/search",
 								"/api/cleanspeak/notify",
 								"/api/connector",
 								"/api/consent",


### PR DESCRIPTION
The `/api/application/search` endpoint is used to search for applications and has been available since 1.45.0.

https://fusionauth.io/docs/apis/applications#search-for-applications