### PR TITLE
Add usage_data_configuration to system_configuration resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This provider is used for setting up [FusionAuth](https://fusionauth.io).
 
-For the rendered provider usage documentation, visit the [Terraform Registry](https://registry.terraform.io/providers/gpsinsight/fusionauth/latest/docs).
+For the rendered provider usage documentation, visit the [Terraform Registry](https://registry.terraform.io/providers/FusionAuth/fusionauth/latest/docs).
 
 ## Please Read 
 

--- a/docs/resources/system_configuration.md
+++ b/docs/resources/system_configuration.md
@@ -45,6 +45,8 @@ resource "fusionauth_system_configuration" "example" {
     - `header_color` - (Optional) A hexadecimal color to override the default menu color in the user interface.
     - `logo_url` - (Optional) A URL of a logo to override the default FusionAuth logo in the user interface.
     - `menu_font_color` - (Optional) A hexadecimal color to override the default menu font color in the user interface.
+* `usage_data_configuration` - (Optional)
+    - `enabled` - (Optional) Whether or not FusionAuth collects and sends usage data to improve the product.
 * `webhook_event_log_configuration` - (Optional)
     - `delete` - (Optional)
         * `enabled` - (Optional) Whether or not FusionAuth should delete the webhook event logs based upon this configuration. When true the webhookEventLogConfiguration.delete.numberOfDaysToRetain will be used to identify webhook event logs that are eligible for deletion. When this value is set to false webhook event logs will be preserved forever.

--- a/fusionauth/resource_system_configuration.go
+++ b/fusionauth/resource_system_configuration.go
@@ -187,6 +187,23 @@ func resourceSystemConfiguration() *schema.Resource {
 					},
 				},
 			},
+			"usage_data_configuration": {
+				Type:       schema.TypeList,
+				MaxItems:   1,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Whether or not FusionAuth collects and sends usage data to improve the product.",
+						},
+					},
+				},
+			},
 			"webhook_event_log_configuration": {
 				Type:       schema.TypeList,
 				MaxItems:   1,
@@ -337,6 +354,10 @@ func buildSystemConfigurationRequest(data *schema.ResourceData) fusionauth.Syste
 		sc.SystemConfiguration.UiConfiguration.MenuFontColor = v.(string)
 	}
 
+	if v, ok := data.GetOk("usage_data_configuration.0.enabled"); ok {
+		sc.SystemConfiguration.UsageDataConfiguration.Enabled = v.(bool)
+	}
+
 	if v, ok := data.GetOk("webhook_event_log_configuration.0.delete.0.enabled"); ok {
 		sc.SystemConfiguration.WebhookEventLogConfiguration.Delete.Enabled = v.(bool)
 	}
@@ -413,6 +434,15 @@ func buildResourceFromSystemConfiguration(sc fusionauth.SystemConfiguration, dat
 	})
 	if err != nil {
 		return diag.Errorf("system_configuration.ui_configuration: %s", err.Error())
+	}
+
+	err = data.Set("usage_data_configuration", []map[string]interface{}{
+		{
+			"enabled": sc.UsageDataConfiguration.Enabled,
+		},
+	})
+	if err != nil {
+		return diag.Errorf("system_configuration.usage_data_configuration: %s", err.Error())
 	}
 
 	err = data.Set("webhook_event_log_configuration", []map[string]interface{}{

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gpsinsight/terraform-provider-fusionauth
 go 1.20
 
 require (
-	github.com/FusionAuth/go-client v0.0.0-20240912225700-ce40548e5bef
+	github.com/FusionAuth/go-client v0.0.0-20241221155813-3c38fd514d84
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 github.com/FusionAuth/go-client v0.0.0-20240912225700-ce40548e5bef h1:BRn4829CZpFBMp9afGlru7+9p/4U1m7ELhghd6vcRWg=
 github.com/FusionAuth/go-client v0.0.0-20240912225700-ce40548e5bef/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
+github.com/FusionAuth/go-client v0.0.0-20241221155813-3c38fd514d84 h1:3Q410BVsX1W4qYpyDsN6d2bUJ3lm9JPfEJs0nO8awGw=
+github.com/FusionAuth/go-client v0.0.0-20241221155813-3c38fd514d84/go.mod h1:SyRrXMJAzMVQLiJjKfQUR59dRI3jPyZv+BXIZ//HwE4=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=


### PR DESCRIPTION
## Overview
- Updated FusionAuth go-client to access newly added `UsageDataConfiguration`
- Added `usage_data_configuration` to `system_configuration` resource
- Updated link to Terraform provider location. It was still pointing to `gpsinsight`
