### PR TITLE
Adds a nil check to handleStringSliceFromList

### DIFF
--- a/fusionauth/helpers.go
+++ b/fusionauth/helpers.go
@@ -20,9 +20,11 @@ func handleStringSliceFromList(list []interface{}) []string {
 	s := make([]string, 0, len(list))
 
 	for _, x := range list {
-		s = append(s, x.(string))
+		if x != nil {
+			s = append(s, x.(string))
+		}
 	}
-
+	
 	return s
 }
 

--- a/fusionauth/helpers_test.go
+++ b/fusionauth/helpers_test.go
@@ -5,6 +5,76 @@ import (
 	"testing"
 )
 
+func Test_handleStringSliceFromList(t *testing.T) {
+	tests := []struct {
+		name      string
+		list      []interface{}
+		want      []string
+		wantPanic bool
+	}{
+		{
+			name:      "empty list",
+			list:      []interface{}{},
+			want:      []string{},
+			wantPanic: false,
+		},
+		{
+			name:      "all strings",
+			list:      []interface{}{"hello", "world"},
+			want:      []string{"hello", "world"},
+			wantPanic: false,
+		},
+		{
+			name:      "mixed types",
+			list:      []interface{}{"string1", 42, "string2"},
+			want:      nil,
+			wantPanic: true,
+		},
+		{
+			name:      "nil element",
+			list:      []interface{}{"valid", nil, "also valid"},
+			want:      []string{"valid", "also valid"},
+			wantPanic: false,
+		},
+		{
+			name:      "multiple nil elements",
+			list:      []interface{}{nil, "middle", nil},
+			want:      []string{"middle"},
+			wantPanic: false,
+		},
+		{
+			name:      "all nil elements",
+			list:      []interface{}{nil, nil, nil},
+			want:      []string{},
+			wantPanic: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			var didPanic bool
+			
+			defer func() {
+				if r := recover(); r != nil {
+					didPanic = true
+				}
+				
+				if didPanic != tt.wantPanic {
+					t.Errorf("handleStringSliceFromList() panic = %v, wantPanic %v", didPanic, tt.wantPanic)
+					return
+				}
+				
+				if !didPanic && !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("handleStringSliceFromList() = %v, want %v", got, tt.want)
+				}
+			}()
+			
+			got = handleStringSliceFromList(tt.list)
+		})
+	}
+}
+
 func Test_intMapToStringMap(t *testing.T) {
 	type args struct {
 		intMap map[string]interface{}


### PR DESCRIPTION
Addressing https://github.com/hashicorp/terraform-plugin-sdk/issues/741

Terraform's SDK API is a bit inconsistent in handling unset or empty strings for lists (see the issue above) causing empty strings, for TypeList only, to come across as nil. 

If needed, I can come up with a reproduction but the above-mentioned issue has a lot of context already.